### PR TITLE
feat: add reviewers to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,23 @@ updates:
     directory: "/.github/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "gliff-ai/techteam"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "gliff-ai/techteam"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "gliff-ai/techteam"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "gliff-ai/techteam"


### PR DESCRIPTION
# Description

I realised there were no reviewers being added to the dependabot alerts.

# Dependency changes

N/A

# Testing

N/A

# Documentation

N/A

# Checklist:

N/A