### PR TITLE
add cert for SSL db connections

### DIFF
--- a/server/settings/cloud.py
+++ b/server/settings/cloud.py
@@ -17,6 +17,7 @@ DATABASES = {
         "PASSWORD": get_env_value("POSTGRES_PASSWORD"),
         "USER": get_env_value("POSTGRES_USER"),
         "PORT": 5432,
+        "OPTIONS": {"ssl": {"ca": "/store_media/cert/BaltimoreCyberTrustRoot.crt.pem"}},
     }
 }
 


### PR DESCRIPTION
Azure wants SSL connections to the db, we put the cert in the static storage drive on azure and access it like this