### PR TITLE
fix: saving user_profile and assigning it to user

### DIFF
--- a/server/api/user.py
+++ b/server/api/user.py
@@ -80,7 +80,7 @@ def create_user(request, payload: UserProfileIn):
             to_emails=user.email,
         )
         message.dynamic_template_data = {
-            "verify_url": settings.BASE_URL + "/verify?uid=" + uid,
+            "verify_url": settings.BASE_URL + "/verify_email/" + uid,
         }
         message.template_id = email_template.id["verify_email"]
 


### PR DESCRIPTION
# Description

Saving `user_profile` and associating it with `user` in `create_user`; prevents `myauth.models.User.userprofile.RelatedObjectDoesNotExist: User has no userprofile.` from happening.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
