### PR TITLE
Fix bug in create_user

### DIFF
--- a/server/api/user.py
+++ b/server/api/user.py
@@ -41,7 +41,7 @@ def create_user(request, payload: UserProfileIn):
     if payload.team_id is None:
         # Create a team for this user. All teams are on the basic plan until we have processed payment
         tier = Tier.objects.get(name__exact="COMMUNITY")
-        team = Team.objects.create(owner_id=user.id, tier_id=tier.id)
+        team = Team.objects.create(owner_id=user.id, tier_id=tier.id, usage=0)
     else:
         try:
             invite = Invite.objects.get(from_team=payload.team_id, uid=payload.invite_id, email=user.email)


### PR DESCRIPTION
# Description

Was getting 500 errors when trying to create a new account, caused by the `UserProfile` returned by `create_user` violating the pydantic schema by not having `team.usage` set (see `server/api/schemas.py`).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
