### PR TITLE
Return 204 from GET /django/api/user if user has no UserProfile

### DIFF
--- a/server/api/user.py
+++ b/server/api/user.py
@@ -97,13 +97,16 @@ def create_user(request, payload: UserProfileIn):
     return user_profile
 
 
-@router.get("/", response=UserProfileOut)
+@router.get("/", response={200: UserProfileOut, 204: None})
 def get_user(request):
-    user = request.auth
-    user.userprofile.id = user.id
-    user.userprofile.email = user.email
+    try:
+        user = request.auth
+        user.userprofile.id = user.id
+        user.userprofile.email = user.email
 
-    return user.userprofile
+        return user.userprofile
+    except UserProfile.DoesNotExist:
+        return 204, None
 
 
 @router.put("/", response=UserProfileOut)  # Update a user profile


### PR DESCRIPTION
# Description

During account creation, the frontend always makes a `GET /django/api/user` request right after the etebase account creation step succeeds, but before the django part has begun. This causes the server to 500 because the user has no `UserProfile` at that point. So now the server returns 204 with empty payload when that happens. I don't think it actually causes any problems clientside, because the retrieved `UserProfile` doesn't seem to be used for anything yet and should be set to `null` in this case anyway. If we do need it at some point then we might have to call `updateUser` again in use-auth.tsx sometime *after* the account is fully created.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
