### PR TITLE
build: Replace django-storages master with pjsier:update-azure-storag…

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -43,8 +43,8 @@ PyNaCl = "==1.4.0"
 PyYAML = "==5.3.1"
 psycopg2-binary = ">=2.9.1"
 django-apscheduler = ">=0.6.0"
-django-storages = {editable = true, ref = "update-azure-storage", git = "https://github.com/pjsier/django-storages.git"}
 azure-storage-blob = "==12.8.1"
+django-storages = {ref = "update-azure-storage", git = "https://github.com/pjsier/django-storages.git"}
 
 [dev-packages]
 black = "==21.6b0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ba1012b027d8b6842a2d694c453cd6d651ca53591388cba4fdf1968407ef2668"
+            "sha256": "61916fa77ad577b59e4c2be9e4793b49678ff4f0170119e4e3902dc8a7e75c95"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -212,7 +212,6 @@
             "version": "==0.13.2"
         },
         "django-storages": {
-            "editable": true,
             "git": "https://github.com/pjsier/django-storages.git",
             "ref": "fb519de50b136dbdff37d72e8c564099c0aa088e"
         },

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@
 
 -i https://pypi.org/simple
 -e ./etebase-server
--e git+https://github.com/pjsier/django-storages.git@fb519de50b136dbdff37d72e8c564099c0aa088e#egg=django-storages
 aiofiles==0.6.0
 aioredis==1.3.1
 appdirs==1.4.4
@@ -33,6 +32,7 @@ django-ninja==0.13.2
 django==3.1.4
 fastapi==0.63.0
 flake8==3.9.2
+git+https://github.com/pjsier/django-storages.git@fb519de50b136dbdff37d72e8c564099c0aa088e#egg=django-storages
 h11==0.11.0
 hiredis==1.1.0
 httptools==0.1.1


### PR DESCRIPTION
#Description
Installed django-storages's branch https://github.com/jschneier/django-storages/pull/805 that supports `azure-storage-blob `versions >=12.0.0.

# Dependency changes

- replaced `django-storages = {version = "==1.11.1", extras = ["azure"]}` with `django-storages = {editable = true, ref = "update-azure-storage", git = "https://github.com/pjsier/django-storages.git"}`
- updated `azure-storage-blob` from `2.1.0` to `12.8.1`

# Testing
No

# Documentation
No

# Migrations (if applicable)

Have any database migrations been committed as part of this pull request?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
