### PR TITLE
Allow list_multi when project limit reached

### DIFF
--- a/server/api/middleware/EnforcePlanLimitsMiddleware.py
+++ b/server/api/middleware/EnforcePlanLimitsMiddleware.py
@@ -23,7 +23,7 @@ class EnforcePlanLimitsMiddleware:
         response = None
 
         # Projects
-        if scope["path"].startswith("/api/v1/collection") and not "list_multi" in scope["path"] and team_limits["projects_limit"] is not None:
+        if scope["path"].startswith("/api/v1/collection") and "list_multi" not in scope["path"] and team_limits["projects_limit"] is not None:
             if team_limits["projects"] >= team_limits["projects_limit"]:
                 logger.info("Can't create a new project, limit is reached")
                 response = JSONResponse({"message": "Can't create a new project, limit is reached"}, status_code=401)


### PR DESCRIPTION
## Description

I was getting `Can't create a new project, limit is reached` when DOMINATE tries to list existing projects (line 228 in dominate/src/etebase/index.ts), so I've added an exception to the rule for `list_multi`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
