### PR TITLE
fix: narrow the add project restriction

### DIFF
--- a/server/api/middleware/EnforcePlanLimitsMiddleware.py
+++ b/server/api/middleware/EnforcePlanLimitsMiddleware.py
@@ -22,8 +22,15 @@ class EnforcePlanLimitsMiddleware:
 
         response = None
 
-        # Projects
-        if scope["path"].startswith("/api/v1/collection") and "list_multi" not in scope["path"] and team_limits["projects_limit"] is not None:
+        # Projects (There may be other end points that need adding here)
+        if (
+            scope["path"].endswith("/api/v1/collection") or scope["path"].endswith("/api/v1/collection/")
+        ) and team_limits["projects_limit"] is not None:
+            if team_limits["projects"] >= team_limits["projects_limit"]:
+                logger.info("Can't create a new project, limit is reached")
+                response = JSONResponse({"message": "Can't create a new project, limit is reached"}, status_code=401)
+
+            # Users
             if team_limits["projects"] >= team_limits["projects_limit"]:
                 logger.info("Can't create a new project, limit is reached")
                 response = JSONResponse({"message": "Can't create a new project, limit is reached"}, status_code=401)


### PR DESCRIPTION
Turns out loads of useful endpoints start with `/api/v1/collection` (Getting images, uploading images) so be more specific with the restriction so we can still use curate.