### PR TITLE
chore: Add is_trusted_service to UserProfileOut

### DIFF
--- a/server/api/schemas.py
+++ b/server/api/schemas.py
@@ -59,6 +59,7 @@ class UserProfileOut(Schema):
     email: str
     email_verified: typing.Any  # we cast this to a bool
     is_collaborator: bool
+    is_trusted_service: bool
     team: TeamSchema
 
 


### PR DESCRIPTION
## Description
Add `is_trusted_service` to `UserProfileOut` so that the list of user profiles returned by`get_team` includes `is_trusted_service`. 