### PR TITLE
fix: Migration 0029_auto_20220202_1054

### DIFF
--- a/myauth/migrations/0029_auto_20220202_1054.py
+++ b/myauth/migrations/0029_auto_20220202_1054.py
@@ -6,55 +6,79 @@ import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
+    def transfer_trustedservices_to_plugins(apps, schema_editor):
+        TrustedService = apps.get_model("myauth", "TrustedService")
+        Plugin = apps.get_model("myauth", "Plugin")
+        trusted_services = TrustedService.objects.all()
+
+        for ts in trusted_services:
+            plugin = Plugin.objects.create(
+                name=ts.name,
+                type=ts.type,
+                team_id=ts.team.id,
+                url=ts.url,
+                products=ts.products,
+                enabled=ts.enabled,
+            )
+            ts.plugin = plugin
+            ts.save()
 
     dependencies = [
-        ('myauth', '0028_plugin_type'),
+        ("myauth", "0028_plugin_type"),
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name='trustedservice',
-            name='enabled',
-        ),
-        migrations.RemoveField(
-            model_name='trustedservice',
-            name='name',
-        ),
-        migrations.RemoveField(
-            model_name='trustedservice',
-            name='products',
-        ),
-        migrations.RemoveField(
-            model_name='trustedservice',
-            name='team',
-        ),
-        migrations.RemoveField(
-            model_name='trustedservice',
-            name='type',
-        ),
-        migrations.RemoveField(
-            model_name='trustedservice',
-            name='url',
-        ),
         migrations.AddField(
-            model_name='trustedservice',
-            name='plugin',
-            field=models.ForeignKey(default=None, on_delete=django.db.models.deletion.CASCADE, to='myauth.plugin', unique=True),
+            model_name="trustedservice",
+            name="plugin",
+            field=models.ForeignKey(
+                default=None, on_delete=django.db.models.deletion.CASCADE, to="myauth.plugin", unique=True, null=True
+            ),
             preserve_default=False,
         ),
         migrations.AlterField(
-            model_name='plugin',
-            name='team',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.RESTRICT, to='myauth.team'),
+            model_name="plugin",
+            name="team",
+            field=models.ForeignKey(on_delete=django.db.models.deletion.RESTRICT, to="myauth.team"),
         ),
         migrations.AlterField(
-            model_name='plugin',
-            name='url',
+            model_name="plugin",
+            name="url",
             field=models.URLField(),
         ),
+        migrations.RunPython(transfer_trustedservices_to_plugins),
+        migrations.RemoveField(
+            model_name="trustedservice",
+            name="enabled",
+        ),
+        migrations.RemoveField(
+            model_name="trustedservice",
+            name="name",
+        ),
+        migrations.RemoveField(
+            model_name="trustedservice",
+            name="products",
+        ),
+        migrations.RemoveField(
+            model_name="trustedservice",
+            name="team",
+        ),
+        migrations.RemoveField(
+            model_name="trustedservice",
+            name="type",
+        ),
+        migrations.RemoveField(
+            model_name="trustedservice",
+            name="url",
+        ),
         migrations.AlterField(
-            model_name='trustedservice',
-            name='user',
+            model_name="trustedservice",
+            name="user",
             field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AlterField(
+            model_name="trustedservice",
+            name="plugin",
+            field=models.OneToOneField(null=False, on_delete=django.db.models.deletion.CASCADE, to="myauth.plugin"),
         ),
     ]


### PR DESCRIPTION
## Description

Fix migration 0029 (first that fails), by re-arranging the list of operations and by adding a function that turns trusted-services into new plugins and that links plugins to trusted-services.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
