### PR TITLE
feat: make it possible to run deploys from GitHub

### DIFF
--- a/.github/workflows/deploy_store-staging-gliff.yml
+++ b/.github/workflows/deploy_store-staging-gliff.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - staging
+  workflow_dispatch:
 
 jobs:
     build_and_deploy:


### PR DESCRIPTION
## Description

These two small changes will add a button to the staging workflows so that it can be run on request. If staging store appear to go down, try rerunning the workflow and then waiting 5 minutes to see if it solves the problem.