### PR TITLE
fix: welcome_email

### DIFF
--- a/server/api/user.py
+++ b/server/api/user.py
@@ -360,6 +360,8 @@ def verify_email(request, verification_id: str):
 
         user.save()
 
+        validation.delete()
+
         # Send welcome email
         try:
             message = Mail(


### PR DESCRIPTION
We allow verifications to be reused, each time sending a welcome email. This removes the verification token once we have verified the account so hitting the endpoint multiple times won't result in several emails

fix https://github.com/gliff-ai/dominate/issues/653