### PR TITLE
feat: Include info about pending invitations in the response of get_trusted_service

### DIFF
--- a/server/api/schemas.py
+++ b/server/api/schemas.py
@@ -8,13 +8,18 @@ from myauth.models import Tier
 TierSchema = create_schema(Tier)
 
 
+class CollectionUid(Schema):
+    uid: str
+    is_invite_pending: bool
+
+
 class PluginSchema(Schema):
     type: str
     name: str
     url: str
     products: str
     enabled: bool
-    collection_uids: Optional[Union[List[Dict[str, Union[str, bool]]], List[str]]] = None
+    collection_uids: Optional[Union[List[CollectionUid], List[str]]] = None
 
 
 class PluginCreated(Schema):

--- a/server/api/trusted_service.py
+++ b/server/api/trusted_service.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import List
+from typing import List, Dict, Union
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import URLValidator
 
@@ -9,11 +9,7 @@ from loguru import logger
 
 from myauth.models import TrustedService, Plugin, User, UserProfile
 from django_etebase.models import Collection, CollectionMember
-from .schemas import (
-    TrustedServiceSchema,
-    TrustedServiceCreated,
-    Error,
-)
+from .schemas import TrustedServiceSchema, TrustedServiceCreated, Error
 
 router = Router()
 
@@ -42,7 +38,7 @@ def is_valid_url(url):
 
 
 @router.get("/", response={200: List[TrustedServiceSchema], 403: Error})
-def get_trusted_service(request):
+def get_trusted_service(request, response=TrustedServiceSchema):
     user = request.auth
 
     plugins = Plugin.objects.filter(team_id=user.userprofile.team.id).exclude(type="Javascript")
@@ -52,7 +48,7 @@ def get_trusted_service(request):
         current_collections = CollectionMember.objects.filter(user__email=ts.user.email).values_list(
             "collection__uid", flat=True
         )
-        p.collection_uids = [
+        p.collection_uids: List[Dict[str, Union[str, bool]]] = [
             {"uid": uid, "is_invite_pending": uid not in current_collections}
             for uid in p.collections.values_list("uid", flat=True)
         ]


### PR DESCRIPTION
## Description

- include info in the response of `get_trusted_service` about whether the invites of a plugin to projects are pending or not, by modifiying `collection_uids`, from a list of uids for the collections the plugin is assigned to, to a list of dictionaries with parameters `uid` and `is_invite_pending`.
- update the schema.

relates to gliff-ai/dominate/issues/657

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [x] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [x] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
